### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server for interacting with a [Twist](https://twist.com/home) workspace. Written in Python using the [Twist REST API](https://developer.twist.com/v3/). Currently for testing purposes only.
 
+<a href="https://glama.ai/mcp/servers/@mikemc/twist-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mikemc/twist-mcp-server/badge" alt="Twist Server MCP server" />
+</a>
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Twist MCP Server](https://glama.ai/mcp/servers/@mikemc/twist-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mikemc/twist-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mikemc/twist-mcp-server/badge" alt="Twist Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.